### PR TITLE
Guarantee ASCII encoding at the type level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true }
+ascii = { version = "1.0", default-features = false }
 
 [features]
 default = ["std"]
-std = []
+std = ["ascii/std"]


### PR DESCRIPTION
We can use the `ascii` crate to require the internal buffer is the correct encoding, but it could prove to be an ergonomics issue

- [ ] Constructor for normal `str`s